### PR TITLE
Feature/safe insight deletation

### DIFF
--- a/src/capstone/__init__.py
+++ b/src/capstone/__init__.py
@@ -1,3 +1,4 @@
 """Capstone analyzer package."""
+from .insight_store import InsightStore, Insight 
 
 __all__ = []

--- a/src/capstone/cli.py
+++ b/src/capstone/cli.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-
+from .insight_store import InsightStore
 from .config import load_config, reset_config
 from .consent import (
     ConsentError,
@@ -23,6 +23,8 @@ from .zip_analyzer import InvalidArchiveError, ZipAnalyzer
 
 logger = get_logger(__name__)
 
+def _print(obj):
+    print(json.dumps(obj, indent=2))
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Capstone zip analyzer (Python implementation).")
@@ -236,8 +238,60 @@ def main(argv: list[str] | None = None) -> int:
         return _handle_analyze(args)
 
     parser.print_help()
-    return 1
+    p = argparse.ArgumentParser(prog="capstone")
+    p.add_argument("--db", default="capstone.db", help="SQLite DB path")
+    sub = p.add_subparsers(dest="cmd", required=True)
 
+    sc = sub.add_parser("insight-create", help="Create a new insight")
+    sc.add_argument("--title", required=True)
+    sc.add_argument("--owner", required=True)
+    sc.add_argument("--uri")
+
+    sd = sub.add_parser("dep-add", help="Add dependency (insight -> insight)")
+    sd.add_argument("--from", dest="from_id", required=True)
+    sd.add_argument("--to", dest="to_id", required=True)
+
+    sdd = sub.add_parser("delete", help="Safe delete workflow")
+    sdd.add_argument("--id", required=True)
+    sdd.add_argument("--strategy", choices=["block", "cascade"], default="block")
+    sdd.add_argument("--dry-run", action="store_true")
+    sdd.add_argument("--who", default="cli")
+
+    sr = sub.add_parser("restore", help="Restore from trash by root id")
+    sr.add_argument("--id", required=True)
+    sr.add_argument("--who", default="cli")
+
+    sp = sub.add_parser("purge", help="Hard delete a single insight (must be free)")
+    sp.add_argument("--id", required=True)
+    sp.add_argument("--who", default="cli")
+
+    st = sub.add_parser("trash", help="List trash")
+    sa = sub.add_parser("audit", help="List audit")
+    sa.add_argument("--target")
+
+    args = p.parse_args()
+    store = InsightStore(args.db)
+
+    if args.cmd == "insight-create":
+        iid = store.create_insight(args.title, args.owner, args.uri)
+        _print({"id": iid})
+    elif args.cmd == "dep-add":
+        store.add_dep_on_insight(args.from_id, args.to_id)
+        _print({"ok": True})
+    elif args.cmd == "delete":
+        if args.dry_run:
+            _print(store.dry_run_delete(args.id, args.strategy))
+        else:
+            _print(store.soft_delete(args.id, who=args.who, strategy=args.strategy))
+    elif args.cmd == "restore":
+        _print(store.restore(args.id, who=args.who))
+    elif args.cmd == "purge":
+        _print(store.purge(args.id, who=args.who))
+    elif args.cmd == "trash":
+        _print(store.list_trash())
+    elif args.cmd == "audit":
+        _print(store.get_audit(args.target))
+    return 1
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     sys.exit(main())

--- a/tests/test_safe_delete.py
+++ b/tests/test_safe_delete.py
@@ -1,0 +1,101 @@
+# tests/test_safe_delete_unittest.py
+import os
+import tempfile
+import unittest
+
+from capstone.insight_store import InsightStore
+
+
+class SafeDeleteTests(unittest.TestCase):
+    def setUp(self):
+        # each test gets its own temp sqlite file
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.tmpdir.name, "test.db")
+        self.store = InsightStore(self.db_path)
+
+    def tearDown(self):
+        # close DB so Windows can delete the temp file
+        try:
+            self.store.close()
+        finally:
+            self.tmpdir.cleanup()
+
+
+    def test_block_delete_when_in_use(self):
+        a = self.store.create_insight("A", "u")
+        b = self.store.create_insight("B", "u")
+        self.store.add_dep_on_insight(b, a)  # B -> A (A has an incoming edge)
+
+        dr = self.store.dry_run_delete(a, strategy="block")
+        self.assertFalse(dr["ok"])
+        self.assertEqual(dr["reason"], "in_use")
+        self.assertEqual(dr["refcount"], 1)
+        self.assertEqual(dr["dependents"], [b])
+
+    def test_cascade_dry_run_lists_closure(self):
+        a = self.store.create_insight("A", "u")
+        b = self.store.create_insight("B", "u")
+        c = self.store.create_insight("C", "u")
+        d = self.store.create_insight("D", "u")
+        # D -> C -> B -> A (so deleting A with cascade should remove all four)
+        self.store.add_dep_on_insight(c, b)
+        self.store.add_dep_on_insight(b, a)
+        self.store.add_dep_on_insight(d, c)
+
+        dr = self.store.dry_run_delete(a, strategy="cascade")
+        self.assertTrue(dr["ok"])
+        targets = set(dr["plan"]["targets"])
+        self.assertSetEqual(targets, {a, b, c, d})
+
+    def test_soft_delete_and_restore_roundtrip(self):
+        root = self.store.create_insight("Root", "me")
+        x = self.store.create_insight("X", "me")
+        y = self.store.create_insight("Y", "me")
+        # X -> Root, Y independent
+        self.store.add_dep_on_insight(x, root)
+
+        res = self.store.soft_delete(root, who="tester", strategy="cascade")
+        self.assertTrue(res["ok"])
+        trash = self.store.list_trash()
+        self.assertEqual(len(trash), 1)
+        self.assertEqual(trash[0]["id"], root)
+
+        # both root and X should be marked deleted
+        for iid in (root, x):
+            ins = self.store.get_insight(iid)
+            self.assertIsNotNone(ins)
+            self.assertIsNotNone(ins.deleted_at)
+
+        rr = self.store.restore(root, who="tester")
+        self.assertTrue(rr["ok"])
+        self.assertEqual(self.store.list_trash(), [])
+        for iid in (root, x):
+            ins = self.store.get_insight(iid)
+            self.assertIsNotNone(ins)
+            self.assertIsNone(ins.deleted_at)
+
+    def test_purge_requires_no_dependents(self):
+        a = self.store.create_insight("A", "u")
+        b = self.store.create_insight("B", "u")
+        self.store.add_dep_on_insight(b, a)
+
+        blocked = self.store.purge(a, who="tester")
+        self.assertFalse(blocked["ok"])
+        self.assertEqual(blocked["reason"], "in_use")
+
+        # remove dependent first
+        self.store.soft_delete(b, who="tester", strategy="block")
+        ok = self.store.purge(a, who="tester")
+        self.assertTrue(ok["ok"])
+
+    def test_audit_trail(self):
+        a = self.store.create_insight("A", "u")
+        self.store.soft_delete(a, who="alice", strategy="block")
+        self.store.restore(a, who="bob")
+        events = self.store.get_audit(target_id=a)
+        actions = [e["action"] for e in events]
+        self.assertEqual(actions, ["soft_delete", "restore"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

Implements Safe Insight Deletion for the Python backend.

- Adds a SQLite-backed `InsightStore` with an insight catalog, stable ids, dependency graph, reference counting, trash, restore, purge, and an append-only audit log.
- Deletion workflow supports dry-run, preview, confirm, and soft delete by default, with optional cascade. Refcount only counts active dependents so soft-deleted items do not block purge.
- CLI wiring in `capstone/cli.py` for creating insights, adding dependencies, dry-run, soft delete, restore, purge, audit, and trash listing.
- Optional FastAPI surface (`capstone/api.py`) for future Electron integration.
- Unittests covering block vs cascade behavior, round-trip restore, purge rules, and audit trail. Windows file locking handled by closing the connection in tests.


**Closes:** # 66

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Automated
- Added `tests/test_safe_delete.py` using `unittest`
  - Blocks delete when refcount greater than zero
  - Cascade dry-run returns full dependent closure
  - Soft delete and restore return the system to the previous state
  - Purge requires no active dependents
  - Audit trail records soft delete and restore

Run
```bash
python -m unittest discover -s tests -p "test_safe_delete.py" -v
```

if it was successful you should get an output like this

<img width="597" height="272" alt="image" src="https://github.com/user-attachments/assets/d02f0dea-e712-43d6-909b-f7730195c3d7" />


---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
