### PR TITLE
resume customization

### DIFF
--- a/src/capstone/cli.py
+++ b/src/capstone/cli.py
@@ -41,9 +41,13 @@ from .resume_retrieval import (
     export_resume,
     query_resume_entries,
     ensure_resume_schema,
+    get_resume_project_description,
+    list_resume_project_descriptions,
+    upsert_resume_project_description,
 )
 from .job_matching import build_jd_profile, rank_projects_for_job
 from .resume_generator import generate_tailored_resume, resume_to_json, resume_to_pdf
+from .portfolio_retrieval import create_app as create_portfolio_app
 from .portfolio_retrieval import ensure_indexes as ensure_portfolio_indexes
 from .portfolio_retrieval import list_snapshots as list_portfolio_snapshots
 from .portfolio_retrieval import get_latest_snapshot as get_portfolio_latest
@@ -358,6 +362,77 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include entries flagged as outdated or expired",
     )
 
+    resume_project_parser = subparsers.add_parser(
+        "resume-project",
+        help="Save or retrieve resume-specific project wording",
+    )
+    resume_project_parser.add_argument(
+        "action",
+        choices=["set", "get", "list"],
+        help="Action to perform",
+    )
+    resume_project_parser.add_argument(
+        "--db-dir",
+        type=Path,
+        default=None,
+        help="Directory where capstone.db is stored",
+    )
+    resume_project_parser.add_argument(
+        "--project-id",
+        action="append",
+        help="Project id to target (repeatable for list)",
+    )
+    resume_project_parser.add_argument(
+        "--summary",
+        type=str,
+        help="Resume-specific project summary text",
+    )
+    resume_project_parser.add_argument(
+        "--summary-file",
+        type=Path,
+        help="File containing the resume-specific project summary text",
+    )
+    resume_project_parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum number of resume project descriptions to load",
+    )
+    resume_project_parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Offset for pagination when listing resume project descriptions",
+    )
+
+    api_parser = subparsers.add_parser(
+        "api",
+        help="Run the local API service",
+    )
+    api_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host interface to bind (default: 127.0.0.1)",
+    )
+    api_parser.add_argument(
+        "--port",
+        type=int,
+        default=5000,
+        help="Port to listen on (default: 5000)",
+    )
+    api_parser.add_argument(
+        "--db-dir",
+        type=Path,
+        default=None,
+        help="Directory where capstone.db is stored",
+    )
+    api_parser.add_argument(
+        "--token",
+        type=str,
+        default=None,
+        help="Optional Bearer token to protect API routes",
+    )
+
     # portfolio retrieval
     portfolio_parser = subparsers.add_parser(
         "portfolio",
@@ -587,7 +662,21 @@ def _handle_resume(args: argparse.Namespace) -> int:
             print("No resume entries found that match the provided filters.")
             return 0
 
-        data = export_resume(entries, fmt=args.format, destination=args.output)
+        project_ids = sorted({pid for entry in entries for pid in entry.project_ids})
+        description_map = {}
+        if project_ids:
+            descriptions = list_resume_project_descriptions(
+                conn,
+                project_ids=project_ids,
+                limit=len(project_ids),
+            )
+            description_map = {item.project_id: item for item in descriptions}
+        data = export_resume(
+            entries,
+            fmt=args.format,
+            destination=args.output,
+            project_descriptions=description_map,
+        )
         if args.output:
             print(f"Wrote resume {args.format} export to {args.output}")
             return 0
@@ -606,6 +695,65 @@ def _handle_resume(args: argparse.Namespace) -> int:
             close_db()
         except Exception:
             pass
+
+
+def _handle_resume_project(args: argparse.Namespace) -> int:
+    store = SnapshotStore(args.db_dir)
+    conn = store.open()
+    try:
+        ensure_resume_schema(conn)
+        project_ids = args.project_id or []
+        if args.action in {"set", "get"}:
+            if len(project_ids) != 1:
+                print("resume-project set/get requires exactly one --project-id", file=sys.stderr)
+                return 2
+            project_id = project_ids[0]
+
+        if args.action == "set":
+            summary = args.summary
+            if args.summary_file:
+                summary = args.summary_file.read_text(encoding="utf-8", errors="ignore").strip()
+            if not summary:
+                print("resume-project set requires --summary or --summary-file", file=sys.stderr)
+                return 2
+            result = upsert_resume_project_description(
+                conn,
+                project_id=project_id,
+                summary=summary,
+            )
+            print(json.dumps(result.to_dict(), indent=2))
+            return 0
+
+        if args.action == "get":
+            result = get_resume_project_description(conn, project_id)
+            if not result:
+                print(json.dumps({"error": "NotFound", "detail": "No resume project description found"}, indent=2))
+                return 0
+            print(json.dumps(result.to_dict(), indent=2))
+            return 0
+
+        if args.action == "list":
+            results = list_resume_project_descriptions(
+                conn,
+                project_ids=project_ids or None,
+                limit=args.limit,
+                offset=args.offset,
+            )
+            print(json.dumps([item.to_dict() for item in results], indent=2))
+            return 0
+
+        print("Unknown resume-project action", file=sys.stderr)
+        return 1
+    finally:
+        store.close()
+
+
+def _handle_api(args: argparse.Namespace) -> int:
+    db_dir = str(args.db_dir) if args.db_dir else None
+    app = create_portfolio_app(db_dir=db_dir, auth_token=args.token)
+    app.run(host=args.host, port=args.port)
+    return 0
+
 
 def _handle_portfolio(args: argparse.Namespace) -> int:
     store = SnapshotStore(args.db_dir)
@@ -1192,6 +1340,10 @@ def main(argv: list[str] | None = None) -> int:
         return _handle_job_match(args)
     if args.command == "resume":
         return _handle_resume(args)
+    if args.command == "resume-project":
+        return _handle_resume_project(args)
+    if args.command == "api":
+        return _handle_api(args)
     if args.command == "generate-resume":
         return _handle_generate_resume(args)
     if args.command == "portfolio":

--- a/src/capstone/portfolio_retrieval.py
+++ b/src/capstone/portfolio_retrieval.py
@@ -19,6 +19,13 @@ except Exception:
     _close_db = None
     _fetch_latest_snapshot = None
 
+from .resume_retrieval import (
+    ensure_resume_schema,
+    get_resume_project_description,
+    list_resume_project_descriptions,
+    upsert_resume_project_description,
+)
+
 @contextmanager
 def _db_session(db_dir: str | None):
     """
@@ -238,5 +245,53 @@ def create_app(db_dir: Optional[str] = None, auth_token: Optional[str] = None):
             },
             "error": None,
         })
+
+    @app.get("/resume-projects")
+    def resume_projects_get():
+        q = request.args
+        project_ids = q.getlist("projectId")
+        limit = int(q.get("limit", 100))
+        offset = int(q.get("offset", 0))
+        with _db_session(db_dir) as c:
+            ensure_resume_schema(c)
+            if project_ids and len(project_ids) == 1 and q.get("list") != "true":
+                item = get_resume_project_description(c, project_ids[0])
+                if not item:
+                    return jsonify({"data": None, "error": {"code": "NotFound", "detail": "No resume project found"}}), 404
+                return jsonify({"data": item.to_dict(), "error": None})
+            items = list_resume_project_descriptions(
+                c,
+                project_ids=project_ids or None,
+                limit=limit,
+                offset=offset,
+            )
+        payload = [item.to_dict() for item in items]
+        return jsonify({
+            "data": payload,
+            "meta": {"limit": limit, "offset": offset, "total": len(payload)},
+            "error": None,
+        })
+
+    @app.post("/resume-projects")
+    def resume_projects_post():
+        payload = request.get_json(silent=True) or {}
+        project_id = payload.get("projectId") or payload.get("project_id")
+        summary = payload.get("summary")
+        metadata = payload.get("metadata")
+        if not project_id:
+            return jsonify({"data": None, "error": {"code": "BadRequest", "detail": "projectId is required"}}), 400
+        if not summary or not str(summary).strip():
+            return jsonify({"data": None, "error": {"code": "BadRequest", "detail": "summary is required"}}), 400
+        if metadata is not None and not isinstance(metadata, dict):
+            return jsonify({"data": None, "error": {"code": "BadRequest", "detail": "metadata must be an object"}}), 400
+        with _db_session(db_dir) as c:
+            ensure_resume_schema(c)
+            item = upsert_resume_project_description(
+                c,
+                project_id=str(project_id),
+                summary=str(summary).strip(),
+                metadata=metadata if isinstance(metadata, dict) else None,
+            )
+        return jsonify({"data": item.to_dict(), "error": None}), 201
 
     return app

--- a/src/capstone/resume_retrieval.py
+++ b/src/capstone/resume_retrieval.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 from uuid import uuid4
 
 from .logging_utils import get_logger
@@ -118,16 +118,41 @@ def ensure_resume_schema(conn: sqlite3.Connection) -> None:
         );
         CREATE INDEX IF NOT EXISTS idx_resume_entry_links
         ON resume_entry_links(link_type, link_value, entry_id);
+        CREATE TABLE IF NOT EXISTS resume_project_descriptions (
+            project_id TEXT PRIMARY KEY,
+            summary TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            metadata TEXT
+        );
         """
     )
     conn.commit()
+
+
+@dataclass(frozen=True)
+class ResumeProjectDescription:
+    project_id: str
+    summary: str
+    created_at: str
+    updated_at: str
+    metadata: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "summary": self.summary,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "metadata": self.metadata,
+        }
 
 
 def describe_resume_schema(conn: sqlite3.Connection) -> Dict[str, Any]:
     ensure_resume_schema(conn)
     tables = {}
     counts = {}
-    for table in ("resume_entries", "resume_entry_links"):
+    for table in ("resume_entries", "resume_entry_links", "resume_project_descriptions"):
         info = conn.execute(f"PRAGMA table_info({table})").fetchall()
         columns = [
             {"name": row[1], "type": row[2], "notnull": bool(row[3]), "default": row[4]}
@@ -307,12 +332,119 @@ def _fetch_links(conn: sqlite3.Connection, entry_ids: Sequence[str]) -> Dict[str
     }
 
 
+def upsert_resume_project_description(
+    conn: sqlite3.Connection,
+    *,
+    project_id: str,
+    summary: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    created_at: Optional[str] = None,
+    updated_at: Optional[str] = None,
+) -> ResumeProjectDescription:
+    ensure_resume_schema(conn)
+    if not project_id:
+        raise ValueError("project_id must be provided")
+    if not summary:
+        raise ValueError("summary must be provided")
+    now = updated_at or datetime.now(timezone.utc).isoformat()
+    created_value = created_at or now
+    payload = json.dumps(metadata or {})
+    conn.execute(
+        """
+        INSERT INTO resume_project_descriptions(project_id, summary, metadata, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(project_id) DO UPDATE SET
+            summary=excluded.summary,
+            metadata=excluded.metadata,
+            updated_at=excluded.updated_at
+        """,
+        (project_id, summary, payload, created_value, now),
+    )
+    conn.commit()
+    result = get_resume_project_description(conn, project_id)
+    if result is None:
+        raise RuntimeError("Failed to persist resume project description")
+    return result
+
+
+def get_resume_project_description(
+    conn: sqlite3.Connection,
+    project_id: str,
+) -> Optional[ResumeProjectDescription]:
+    ensure_resume_schema(conn)
+    row = conn.execute(
+        """
+        SELECT project_id, summary, created_at, updated_at, metadata
+        FROM resume_project_descriptions
+        WHERE project_id = ?
+        """,
+        (project_id,),
+    ).fetchone()
+    return _row_to_project_description(row) if row else None
+
+
+def list_resume_project_descriptions(
+    conn: sqlite3.Connection,
+    *,
+    project_ids: Optional[Sequence[str]] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> List[ResumeProjectDescription]:
+    ensure_resume_schema(conn)
+    where = ""
+    params: List[Any] = []
+    if project_ids:
+        placeholders = ",".join("?" * len(project_ids))
+        where = f"WHERE project_id IN ({placeholders})"
+        params.extend(list(project_ids))
+    rows = conn.execute(
+        f"""
+        SELECT project_id, summary, created_at, updated_at, metadata
+        FROM resume_project_descriptions
+        {where}
+        ORDER BY updated_at DESC
+        LIMIT ? OFFSET ?
+        """,
+        (*params, max(1, limit), max(0, offset)),
+    ).fetchall()
+    return [_row_to_project_description(row) for row in rows]
+
+
+def _row_to_project_description(row: sqlite3.Row | Sequence[Any]) -> ResumeProjectDescription:
+    metadata: Dict[str, Any] = {}
+    if row[4]:
+        try:
+            metadata = json.loads(row[4])
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse metadata for resume project %s", row[0])
+            metadata = {}
+    return ResumeProjectDescription(
+        project_id=row[0],
+        summary=row[1],
+        created_at=row[2],
+        updated_at=row[3],
+        metadata=metadata,
+    )
+
+
 def resolve_resume_projects(conn: sqlite3.Connection, entries: Iterable[ResumeEntry]) -> Dict[str, Optional[dict]]:
     ids = sorted({pid for entry in entries for pid in entry.project_ids})
     context: Dict[str, Optional[dict]] = {}
     for pid in ids:
         context[pid] = fetch_latest_snapshot(conn, pid)
     return context
+
+
+def resolve_resume_project_descriptions(
+    conn: sqlite3.Connection,
+    entries: Iterable[ResumeEntry],
+) -> Dict[str, Optional[dict]]:
+    ids = sorted({pid for entry in entries for pid in entry.project_ids})
+    if not ids:
+        return {}
+    descriptions = list_resume_project_descriptions(conn, project_ids=ids, limit=len(ids))
+    by_id = {desc.project_id: desc.to_dict() for desc in descriptions}
+    return {pid: by_id.get(pid) for pid in ids}
 
 
 def build_resume_preview(
@@ -344,6 +476,9 @@ def build_resume_preview(
         sections_payload.append({"name": section, "items": grouped[section]})
 
     project_context = resolve_resume_projects(conn, result.entries) if conn else {}
+    resume_project_descriptions = (
+        resolve_resume_project_descriptions(conn, result.entries) if conn else {}
+    )
     last_updated = max((entry.updated for entry in result.entries if entry.updated), default=None)
     preview = {
         "sections": sections_payload,
@@ -351,19 +486,24 @@ def build_resume_preview(
         "missingSections": result.missing_sections,
         "schema": result.schema_state,
         "projectContext": project_context,
+        "resumeProjectDescriptions": resume_project_descriptions,
         "lastUpdated": last_updated.isoformat() if last_updated else None,
     }
     return preview
 
 
-def resume_to_markdown(entries: Sequence[ResumeEntry]) -> str:
+def resume_to_markdown(
+    entries: Sequence[ResumeEntry],
+    *,
+    project_descriptions: Optional[Mapping[str, ResumeProjectDescription]] = None,
+) -> str:
     grouped = _group_by_section(entries)
     lines: List[str] = []
     for section, items in grouped:
         lines.append(f"## {section.title()}")
         for entry in items:
             period = _format_period(entry.metadata)
-            summary = entry.summary or entry.body
+            summary = _resolve_entry_summary(entry, project_descriptions)
             lines.append(f"- **{entry.title}** {period} — {summary.strip()}")
             if entry.skills:
                 lines.append(f"  - Skills: {', '.join(entry.skills)}")
@@ -371,29 +511,53 @@ def resume_to_markdown(entries: Sequence[ResumeEntry]) -> str:
     return "\n".join(line for line in lines if line).strip()
 
 
-def resume_to_json(entries: Sequence[ResumeEntry]) -> Dict[str, Any]:
+def resume_to_json(
+    entries: Sequence[ResumeEntry],
+    *,
+    project_descriptions: Optional[Mapping[str, ResumeProjectDescription]] = None,
+) -> Dict[str, Any]:
     grouped = _group_by_section(entries)
     sections = []
     for section, items in grouped:
-        sections.append({"name": section, "items": [entry.to_dict() for entry in items]})
+        rendered: List[Dict[str, Any]] = []
+        for entry in items:
+            payload = entry.to_dict()
+            summary = _resolve_entry_summary(entry, project_descriptions)
+            if summary:
+                payload["summary"] = summary
+            rendered.append(payload)
+        sections.append({"name": section, "items": rendered})
     return {"generatedAt": datetime.now(timezone.utc).isoformat(), "sections": sections}
 
 
-def resume_to_pdf(entries: Sequence[ResumeEntry]) -> bytes:
-    markdown = resume_to_markdown(entries)
+def resume_to_pdf(
+    entries: Sequence[ResumeEntry],
+    *,
+    project_descriptions: Optional[Mapping[str, ResumeProjectDescription]] = None,
+) -> bytes:
+    markdown = resume_to_markdown(entries, project_descriptions=project_descriptions)
     return _markdown_to_pdf(markdown)
 
 # export in differnt formats
-def export_resume(entries: Sequence[ResumeEntry], *, fmt: str, destination: Optional[Path] = None) -> bytes:
+def export_resume(
+    entries: Sequence[ResumeEntry],
+    *,
+    fmt: str,
+    destination: Optional[Path] = None,
+    project_descriptions: Optional[Mapping[str, ResumeProjectDescription]] = None,
+) -> bytes:
     fmt = fmt.lower()
     if fmt not in {"markdown", "json", "pdf"}:
         raise ValueError(f"Unsupported export format: {fmt}")
     if fmt == "markdown":
-        data = resume_to_markdown(entries).encode("utf-8")
+        data = resume_to_markdown(entries, project_descriptions=project_descriptions).encode("utf-8")
     elif fmt == "json":
-        data = json.dumps(resume_to_json(entries), indent=2).encode("utf-8")
+        data = json.dumps(
+            resume_to_json(entries, project_descriptions=project_descriptions),
+            indent=2,
+        ).encode("utf-8")
     else:
-        data = resume_to_pdf(entries)
+        data = resume_to_pdf(entries, project_descriptions=project_descriptions)
     if destination:
         destination.write_bytes(data)
         logger.info("Wrote resume export (%s) to %s", fmt, destination)
@@ -418,6 +582,18 @@ def _format_period(metadata: Dict[str, Any]) -> str:
     if not start:
         return f"({end})"
     return f"({start} – {end})"
+
+
+def _resolve_entry_summary(
+    entry: ResumeEntry,
+    project_descriptions: Optional[Mapping[str, ResumeProjectDescription]],
+) -> str:
+    if project_descriptions and entry.project_ids:
+        for project_id in entry.project_ids:
+            desc = project_descriptions.get(project_id)
+            if desc and desc.summary:
+                return desc.summary
+    return entry.summary or entry.body
 
 
 def _markdown_to_pdf(markdown: str) -> bytes:
@@ -464,12 +640,17 @@ def _markdown_to_pdf(markdown: str) -> bytes:
 
 __all__ = [
     "ResumeEntry",
+    "ResumeProjectDescription",
     "ResumeRetrievalResult",
     "ensure_resume_schema",
     "describe_resume_schema",
     "insert_resume_entry",
+    "upsert_resume_project_description",
+    "get_resume_project_description",
+    "list_resume_project_descriptions",
     "query_resume_entries",
     "resolve_resume_projects",
+    "resolve_resume_project_descriptions",
     "build_resume_preview",
     "resume_to_markdown",
     "resume_to_json",

--- a/tests/test_resume_retrieval.py
+++ b/tests/test_resume_retrieval.py
@@ -8,11 +8,14 @@ from capstone.resume_retrieval import (
     build_resume_preview,
     describe_resume_schema,
     export_resume,
+    get_resume_project_description,
     insert_resume_entry,
+    list_resume_project_descriptions,
     query_resume_entries,
     resolve_resume_projects,
     resume_to_json,
     resume_to_markdown,
+    upsert_resume_project_description,
 )
 
 
@@ -103,15 +106,45 @@ class ResumeRetrievalTests(unittest.TestCase):
 
     def test_export_formats(self):
         self._create_sample_entries()
+        desc = upsert_resume_project_description(
+            self.conn,
+            project_id="proj-1",
+            summary="Resume-specific project summary.",
+        )
+        desc_map = {desc.project_id: desc}
         result = query_resume_entries(self.conn)
-        markdown = resume_to_markdown(result.entries)
-        self.assertIn("Telemetry Platform", markdown)
-        payload = resume_to_json(result.entries)
+        markdown = resume_to_markdown(result.entries, project_descriptions=desc_map)
+        self.assertIn("Resume-specific project summary.", markdown)
+        payload = resume_to_json(result.entries, project_descriptions=desc_map)
         self.assertIn("sections", payload)
         export_path = Path(self.tmp.name) / "resume.pdf"
-        pdf_bytes = export_resume(result.entries, fmt="pdf", destination=export_path)
+        pdf_bytes = export_resume(
+            result.entries,
+            fmt="pdf",
+            destination=export_path,
+            project_descriptions=desc_map,
+        )
         self.assertTrue(export_path.exists())
         self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+
+    def test_resume_project_description_upsert(self):
+        first = upsert_resume_project_description(
+            self.conn,
+            project_id="proj-1",
+            summary="Concise resume summary.",
+        )
+        self.assertEqual(first.summary, "Concise resume summary.")
+        updated = upsert_resume_project_description(
+            self.conn,
+            project_id="proj-1",
+            summary="Updated resume summary.",
+        )
+        self.assertEqual(updated.summary, "Updated resume summary.")
+        fetched = get_resume_project_description(self.conn, "proj-1")
+        self.assertIsNotNone(fetched)
+        self.assertEqual(fetched.summary, "Updated resume summary.")
+        listed = list_resume_project_descriptions(self.conn)
+        self.assertEqual(len(listed), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description
  
Added a resume‑project description store and API/CLI support so users can customize and save résumé‑specific project wording without altering portfolio text.
 
The milestone requires a human‑in‑the‑loop flow; this change lets users edit and persist concise résumé wording and retrieve it via CLI or API.

**Closes:** #142 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [x] Test A--run 'python -m pytest tests/test_resume_retrieval.py' 
- [x] Test B -- add test: tests/test_resume_retrieval.py: new test_resume_project_description_upsert to verify saving, updating, and
    fetching the resume‑specific project wording.
- [x]  Test C  - add test: tests/test_resume_retrieval.py: updated test_export_formats to inject a custom resume project summary and
    assert it shows up in the markdown/json/pdf outputs.


---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
<img width="820" height="105" alt="Screenshot 2026-01-09 at 8 09 16 PM" src="https://github.com/user-attachments/assets/7b2415ac-ef35-4c41-8046-910c10cf095a" />

</details>
