### PR TITLE
Add project evidence endpoint for portfolio snapshots

### DIFF
--- a/src/capstone/portfolio_retrieval.py
+++ b/src/capstone/portfolio_retrieval.py
@@ -163,6 +163,56 @@ def get_latest_snapshot(conn: sqlite3.Connection, project_id: str) -> Optional[d
     ).fetchone()
     return json.loads(row[0]) if row else None
 
+def _extract_evidence(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Extract a simple evidence/metrics structure from a snapshot.
+    Keeps it robust: handles different key shapes and provides a fallback.
+    """
+    if not isinstance(snapshot, dict):
+        return {"type": "metrics", "items": []}
+
+    # Common places teams store metrics/evidence
+    candidates = [
+        snapshot.get("evidence"),
+        snapshot.get("metrics"),
+        snapshot.get("results"),
+        snapshot.get("evaluation"),
+        snapshot.get("outcomes"),
+    ]
+
+    for c in candidates:
+        # If already in desired shape
+        if isinstance(c, dict) and "items" in c and isinstance(c["items"], list):
+            return {"type": c.get("type", "metrics"), "items": c["items"]}
+
+        # If it's a dict of key->value metrics
+        if isinstance(c, dict):
+            items = [{"label": str(k), "value": str(v)} for k, v in c.items()]
+            if items:
+                return {"type": "metrics", "items": items}
+
+        # If it's a list, assume list of strings or dicts
+        if isinstance(c, list):
+            items = []
+            for it in c:
+                if isinstance(it, dict) and ("label" in it or "value" in it):
+                    items.append({"label": str(it.get("label", "")), "value": str(it.get("value", ""))})
+                else:
+                    items.append({"label": "evidence", "value": str(it)})
+            if items:
+                return {"type": "metrics", "items": items}
+
+    # Fallback evidence (still counts as “evidence of success/summary metrics”)
+    items: List[Dict[str, str]] = []
+    if isinstance(snapshot.get("skills"), list):
+        items.append({"label": "Skills detected", "value": str(len(snapshot["skills"]))})
+    if isinstance(snapshot.get("projects"), list):
+        items.append({"label": "Projects detected", "value": str(len(snapshot["projects"]))})
+    if isinstance(snapshot.get("files"), list):
+        items.append({"label": "Files analyzed", "value": str(len(snapshot["files"]))})
+
+    return {"type": "metrics", "items": items}
+
 
 def create_app(db_dir: Optional[str] = None, auth_token: Optional[str] = None):
     """
@@ -212,6 +262,24 @@ def create_app(db_dir: Optional[str] = None, auth_token: Optional[str] = None):
         if data is None:
             return jsonify({"data": None, "error": {"code": "NotFound", "detail": "No snapshots found"}}), 404
         return jsonify({"data": data, "meta": {"projectId": project_id}, "error": None})
+    @app.get("/portfolios/evidence")
+    def evidence_latest():
+        project_id = request.args.get("projectId", "")
+        if not project_id:
+            return jsonify({"data": None, "error": {"code": "BadRequest", "detail": "projectId is required"}}), 400
+
+        with _db_session(db_dir) as c:
+            ensure_indexes(c)
+            snap = get_latest_snapshot(c, project_id)
+
+        if snap is None:
+            return jsonify({"data": None, "error": {"code": "NotFound", "detail": "No snapshots found"}}), 404
+
+        evidence = _extract_evidence(snap)
+        return jsonify({
+            "data": {"projectId": project_id, "evidence": evidence},
+            "error": None
+        })
 
     @app.get("/portfolios")
     def list_():

--- a/tests/test_portfolio_evidence.py
+++ b/tests/test_portfolio_evidence.py
@@ -1,0 +1,97 @@
+import json
+import sqlite3
+
+import capstone.portfolio_retrieval as pr
+
+
+def _make_db_with_one_snapshot(tmp_path):
+    db_path = tmp_path / "capstone.db"
+    conn = sqlite3.connect(db_path)
+
+    conn.execute("""
+    CREATE TABLE IF NOT EXISTS project_analysis (
+        project_id TEXT NOT NULL,
+        classification TEXT,
+        primary_contributor TEXT,
+        snapshot TEXT NOT NULL,
+        created_at TEXT NOT NULL
+    )
+    """)
+
+    snapshot = {
+        "metrics": {"Accuracy": "92%", "Users": "50+"},
+        "skills": ["Python", "Flask"]
+    }
+
+    conn.execute(
+        "INSERT INTO project_analysis(project_id, classification, primary_contributor, snapshot, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("p1", "demo", "raunak", json.dumps(snapshot), "2026-01-11T00:00:00Z"),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_portfolios_evidence_happy_path(tmp_path, monkeypatch):
+    # Force portfolio_retrieval to use local sqlite fallback instead of capstone.storage.open_db
+    monkeypatch.setattr(pr, "_open_db", None)
+    monkeypatch.setattr(pr, "_close_db", None)
+    monkeypatch.setattr(pr, "_fetch_latest_snapshot", None)
+
+    _make_db_with_one_snapshot(tmp_path)
+
+    app = pr.create_app(db_dir=str(tmp_path), auth_token=None)
+    client = app.test_client()
+
+    resp = client.get("/portfolios/evidence?projectId=p1")
+
+    # If it fails, show body to make debugging instant
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    body = resp.get_json()
+    assert body["error"] is None
+    assert body["data"]["projectId"] == "p1"
+
+    evidence = body["data"]["evidence"]
+    assert evidence["type"] == "metrics"
+    assert any(i["label"] == "Accuracy" and i["value"] == "92%" for i in evidence["items"])
+
+
+def test_portfolios_evidence_missing_project_id(tmp_path, monkeypatch):
+    monkeypatch.setattr(pr, "_open_db", None)
+    monkeypatch.setattr(pr, "_close_db", None)
+    monkeypatch.setattr(pr, "_fetch_latest_snapshot", None)
+
+    app = pr.create_app(db_dir=str(tmp_path), auth_token=None)
+    client = app.test_client()
+
+    resp = client.get("/portfolios/evidence")
+    assert resp.status_code == 400
+
+
+def test_portfolios_evidence_not_found(tmp_path, monkeypatch):
+    monkeypatch.setattr(pr, "_open_db", None)
+    monkeypatch.setattr(pr, "_close_db", None)
+    monkeypatch.setattr(pr, "_fetch_latest_snapshot", None)
+
+    # Create empty DB with table so it doesn't 500
+    db_path = tmp_path / "capstone.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+    CREATE TABLE IF NOT EXISTS project_analysis (
+        project_id TEXT NOT NULL,
+        classification TEXT,
+        primary_contributor TEXT,
+        snapshot TEXT NOT NULL,
+        created_at TEXT NOT NULL
+    )
+    """)
+    conn.commit()
+    conn.close()
+
+    app = pr.create_app(db_dir=str(tmp_path), auth_token=None)
+    client = app.test_client()
+
+    resp = client.get("/portfolios/evidence?projectId=does-not-exist")
+    assert resp.status_code == 404


### PR DESCRIPTION


Add project evidence endpoint for portfolio snapshots

---

### **Description**

#### Summary

This PR introduces a lightweight API endpoint that exposes **evidence of success** (metrics, results, evaluations) for a project based on its **latest portfolio snapshot**. This allows portfolio and résumé views to highlight measurable impact in a structured way.

---

#### Changes

* Added a new endpoint:
  **`GET /portfolios/evidence?projectId=...`**
* Extracts structured evidence/metrics from the latest snapshot
* Provides graceful fallback metrics when explicit evidence is not present
* Added pytest coverage for:

  * Successful evidence retrieval
  * Missing `projectId`
  * Non-existent project handling

---

#### Milestone 2 Alignment

This PR intends to provide an **initial** implementation toward the following Milestone 2 requirements:
Incorporate evidence of success (e.g., metrics, feedback, evaluation)
29 / 30 Display project information for portfolio and résumé contexts
31 Backend API support via Flask

---

#### Testing

* Added `tests/test_portfolio_evidence.py`
* Tests run using Flask’s test client and isolated SQLite database
* All tests pass locally

---

#### Scope & Safety

* No database schema changes
* No impact on existing resume customization or storage logic
* Fully backwards compatible with existing portfolio endpoints

---

#### Example Response

```json
{
  "data": {
    "projectId": "p1",
    "evidence": {
      "type": "metrics",
      "items": [
        { "label": "Accuracy", "value": "92%" },
        { "label": "Users", "value": "50+" }
      ]
    }
  },
  "error": null
}
```

---

#### Checklist

* [x] Implemented on a feature branch
* [x] Tests added and passing
* [x] No overlap with existing PRs
* [x] Milestone 2 requirement satisfied

---
