### PR TITLE
added some missing api endpoints

### DIFF
--- a/src/capstone/api/routes/consent.py
+++ b/src/capstone/api/routes/consent.py
@@ -1,8 +1,21 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
+
 router = APIRouter(tags=["consent"])
+
+# simple in-memory consent store (acceptable for capstone)
+_CONSENT_STATE = {"consent": False}
+
 class ConsentIn(BaseModel):
     consent: bool
+
+
 @router.post("/privacy-consent")
 def privacy_consent(payload: ConsentIn):
+    _CONSENT_STATE["consent"] = payload.consent
     return {"consent": payload.consent}
+
+
+@router.get("/privacy-consent")
+def get_privacy_consent():
+    return {"consent": _CONSENT_STATE["consent"]}

--- a/src/capstone/api/routes/projects.py
+++ b/src/capstone/api/routes/projects.py
@@ -107,3 +107,47 @@ def get_project(project_id: str):
         "size_bytes": row[5],
         "stored_path": row[6],
     }
+
+@router.delete("/{project_id}")
+def delete_project(project_id: str):
+    """
+    Deletes a project upload and its associated stored file.
+    """
+    conn = storage.open_db()
+
+    row = conn.execute(
+        """
+        SELECT u.file_id, f.path
+        FROM uploads u
+        JOIN files f ON f.file_id = u.file_id
+        WHERE u.upload_id = ?
+        """,
+        (project_id,),
+    ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    file_id, file_path = row
+
+    # delete upload reference
+    conn.execute("DELETE FROM uploads WHERE upload_id = ?", (project_id,))
+    # delete file reference
+    conn.execute("DELETE FROM files WHERE file_id = ?", (file_id,))
+    conn.commit()
+
+    # best-effort physical file removal
+    try:
+        Path(file_path).unlink(missing_ok=True)
+    except Exception:
+        pass
+
+    return {
+        "data": {
+            "deleted": True,
+            "project_id": project_id,
+            "file_id": file_id,
+        },
+        "error": None,
+    }
+


### PR DESCRIPTION
## 📝 Description

This PR completes the remaining API gaps identified during review by adding explicit support for reading user consent state and for deleting uploaded projects. These changes improve API completeness, privacy transparency, and lifecycle management without altering existing behavior or database schemas.

Specifically, this PR introduces:

A GET /privacy-consent endpoint to expose the current consent state

A DELETE /projects/{project_id} endpoint to allow cleanup of uploaded projects and associated files

These additions align the API with full CRUD expectations and improve frontend usability while keeping AI functionality properly encapsulated within existing generation endpoints.



**Closes:** # N/A

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement



---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
