### PR TITLE
Add skills timeline to portfolio resume page

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -79,6 +79,7 @@
               <span id="system-status">Checking...</span>
             </div>
 
+
             <div class="gauges">
 
               <!-- CPU -->
@@ -186,6 +187,11 @@
             <div class="card portfolio-skills-card">
               <h2 class="card-title">Portfolio Stats</h2>
               <div id="skills-expertise-container" class="skills-expertise-container"></div>
+            </div>
+      
+            <div class="card portfolio-timeline-card">
+              <h2 class="card-title">Skills Timeline</h2>
+              <div id="skills-timeline-container" class="skills-timeline-container"></div>
             </div>
       
           </div>

--- a/frontend/src/renderer/portfolioResume.js
+++ b/frontend/src/renderer/portfolioResume.js
@@ -19,6 +19,17 @@ function getTopProjects(projects) {
     .slice(0, 3);
 }
 
+async function fetchSkillsTimeline() {
+  const res = await fetch("http://127.0.0.1:8002/skills/timeline");
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch skills timeline: ${res.status}`);
+  }
+
+  const payload = await res.json();
+  return Array.isArray(payload.timeline) ? payload.timeline : [];
+}
+
 function renderResumeSummary(profile, projects) {
   const container = document.getElementById("resume-summary-container");
   if (!container) return;
@@ -30,7 +41,7 @@ function renderResumeSummary(profile, projects) {
   const summary =
     totalProjects > 0
       ? `Built a portfolio with ${totalProjects} uploaded project${totalProjects === 1 ? "" : "s"}, covering ${totalFiles} analyzed file${totalFiles === 1 ? "" : "s"} and ${totalSkills} detected skill signal${totalSkills === 1 ? "" : "s"}.`
-      : "Upload projects to generate a stronger one-page resume summary and portfolio showcase.";
+      : "Upload projects to generate a one-page resume summary and portfolio showcase.";
 
   container.innerHTML = `
     <div class="resume-summary-card">
@@ -150,6 +161,58 @@ function renderPortfolioStats(projects) {
   `;
 }
 
+function renderSkillsTimeline(timeline) {
+  const container = document.getElementById("skills-timeline-container");
+  if (!container) return;
+
+  if (!timeline.length) {
+    container.innerHTML = `
+      <div class="skills-group-card">
+        <h3>No timeline data yet</h3>
+        <p class="resume-summary-text">
+          Upload projects with detected skills to generate a year-by-year skills timeline.
+        </p>
+      </div>
+    `;
+    return;
+  }
+
+  container.innerHTML = timeline
+    .map((entry) => {
+      const skills = Array.isArray(entry.skills) ? entry.skills : [];
+
+      return `
+        <div class="timeline-year-row">
+          <div class="timeline-year">${entry.year}</div>
+          <div class="timeline-track">
+            <div class="timeline-skill-pills">
+              ${
+                skills.length
+                  ? skills
+                      .map((skill) => {
+                        const name = skill.name || skill.skill || "unknown";
+                        const weight =
+                          skill.weight !== undefined && skill.weight !== null
+                            ? `<span class="timeline-weight">${Number(skill.weight).toFixed(1)}</span>`
+                            : "";
+
+                        return `
+                          <span class="timeline-skill-pill">
+                            ${name} ${weight}
+                          </span>
+                        `;
+                      })
+                      .join("")
+                  : `<span class="timeline-empty">No skills recorded</span>`
+              }
+            </div>
+          </div>
+        </div>
+      `;
+    })
+    .join("");
+}
+
 function buildResumePreviewHtml(profile, projects) {
   const totalProjects = projects.length;
   const totalFiles = projects.reduce((sum, p) => sum + (p.total_files || 0), 0);
@@ -251,17 +314,26 @@ function closeResumePreview() {
 export async function loadPortfolioResume() {
   const profile = getStaticProfile();
 
-  try {
-    const projects = await fetchProjects();
-    renderResumeSummary(profile, projects);
-    renderTopProjects(projects);
-    renderPortfolioStats(projects);
-  } catch (err) {
-    console.error("Failed to load portfolio/resume data:", err);
-    renderResumeSummary(profile, []);
-    renderTopProjects([]);
-    renderPortfolioStats([]);
+  const [projectsResult, timelineResult] = await Promise.allSettled([
+    fetchProjects(),
+    fetchSkillsTimeline(),
+  ]);
+
+  const projects = projectsResult.status === "fulfilled" ? projectsResult.value : [];
+  const timeline = timelineResult.status === "fulfilled" ? timelineResult.value : [];
+
+  if (projectsResult.status === "rejected") {
+    console.error("Failed to load portfolio/resume project data:", projectsResult.reason);
   }
+
+  if (timelineResult.status === "rejected") {
+    console.error("Failed to load skills timeline:", timelineResult.reason);
+  }
+
+  renderResumeSummary(profile, projects);
+  renderTopProjects(projects);
+  renderPortfolioStats(projects);
+  renderSkillsTimeline(timeline);
 }
 
 export function initPortfolioResume() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1684,6 +1684,17 @@ transition: all 0.2s ease;
   grid-column: 1 / -1;
 }
 
+.portfolio-timeline-card {
+  grid-column: 1 / -1;
+}
+
+.skills-timeline-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 120px;
+}
+
 .resume-summary-card {
   display: flex;
   flex-direction: column;

--- a/src/capstone/api/routes/skills.py
+++ b/src/capstone/api/routes/skills.py
@@ -1,6 +1,9 @@
 from fastapi import APIRouter, HTTPException
 from pathlib import Path
 import zipfile
+import json
+from tempfile import NamedTemporaryFile
+from capstone.timeline import write_top_skills_by_year
 
 from capstone import storage, file_store
 from capstone.activity_log import log_event
@@ -111,3 +114,44 @@ def skills_all(limit: int = 200):
             for name, stats in sorted(skills.items(), key=lambda it: (-it[1]["projects"], it[0]))
         ],
     }
+
+@router.get("/skills/timeline")
+def skills_timeline(top_n: int = 5):
+    """
+    Return a year-by-year skills timeline using the existing timeline export logic.
+    """
+    tmp_path = None
+
+    try:
+        with NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        write_top_skills_by_year(None, tmp_path, top_n=top_n)
+
+        if not tmp_path.exists() or tmp_path.stat().st_size == 0:
+            return {"timeline": []}
+
+        payload = json.loads(tmp_path.read_text(encoding="utf-8"))
+
+        timeline = []
+        if isinstance(payload, dict):
+            for year, skills in sorted(payload.items(), key=lambda item: item[0]):
+                timeline.append({
+                    "year": str(year),
+                    "skills": skills if isinstance(skills, list) else [],
+                })
+
+        log_event("INFO", f"Skills timeline generated · Years: {len(timeline)}")
+
+        return {
+            "count": len(timeline),
+            "timeline": timeline,
+        }
+
+    except Exception as exc:
+        log_event("ERROR", f"Skills timeline generation failed · {exc}")
+        raise HTTPException(status_code=500, detail="Failed to generate skills timeline")
+
+    finally:
+        if tmp_path and tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
## 📝 Description

This PR adds a **Skills Timeline** feature to the Portfolio & Resume experience in the Electron frontend and exposes a backend API endpoint to support it.

The main goal of this change is to move the project closer to the explicit Milestone 3 web portfolio requirements. The course page states that the final system should generate a **web portfolio** that includes a **timeline of skills demonstrating learning progression and increased expertise/depth**. It also emphasizes that Milestone 3 should focus on polishing the final product around **use case coherence, ease of use, testing, and documentation** rather than adding unrelated features. :contentReference[oaicite:0]{index=0}

This PR contributes to that milestone by:
- adding a new **Skills Timeline** section to the **Portfolio & Resume** page in the Electron frontend
- adding backend support for a **skills timeline API endpoint**
- rendering a year-by-year timeline view in the frontend
- showing a clean empty state when timeline data is not yet available
- keeping the new feature integrated with the existing portfolio/resume workflow rather than building it as a disconnected UI element

### Technical summary
On the backend:
- added a new route in `src/capstone/api/routes/skills.py` to expose timeline-oriented skill data
- reused the existing timeline/analysis pipeline already present in the project rather than creating a separate parallel skills-processing flow
- returned a frontend-friendly response shape for year-by-year skills rendering

On the frontend:
- updated `frontend/src/index.html` to include a dedicated **Skills Timeline** card in the **Portfolio & Resume** page
- updated `frontend/src/renderer/portfolioResume.js` to fetch timeline data from the backend and render it
- updated `frontend/src/style.css` to style the timeline card and timeline rows cleanly within the existing portfolio layout

### Motivation / Context
This work directly supports the course requirements in multiple ways:
- Milestone 1 requires the system to **produce a chronological list of skills exercised**. :contentReference[oaicite:1]{index=1}
- Milestone 2 expects API support including a **GET /skills** style endpoint and explicitly allows teams to add more endpoints as needed. :contentReference[oaicite:2]{index=2}
- Milestone 3 requires the web portfolio to include a **timeline of skills**. :contentReference[oaicite:3]{index=3}

So this PR is not a random enhancement; it extends an already course-aligned backend capability into the final frontend deliverable.

### Impact on the project
This PR improves the system by:
- making the portfolio page more aligned with the actual end-user use case
- surfacing skill progression in a visual and understandable way
- improving feature completeness for Milestone 3
- giving the team a clean base to extend later with richer skill weighting, expertise progression, and additional visualizations

### Dependencies
No new external dependencies were required for this PR.

**Closes:** #254

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

This PR was tested manually with the backend running locally and the Electron frontend launched normally.

### Manual testing performed
- [x] Started the backend API and confirmed the new skills timeline endpoint responds successfully
- [x] Started the Electron frontend and verified the Portfolio & Resume page still renders correctly
- [x] Verified that the new **Skills Timeline** card appears in the correct tab and not on the Dashboard
- [x] Verified that the timeline card spans the layout correctly after CSS adjustment
- [x] Verified that a clean empty state is shown when no timeline data is available
- [x] Verified that the rest of the Portfolio & Resume page still works after integrating the timeline feature

### Reproduction steps
1. Start the backend locally
2. Start the Electron frontend
3. Open the app and go to **Portfolio & Resume**
4. Scroll to the **Skills Timeline** section
5. Confirm the timeline renders if data exists, or that the empty state appears cleanly if no data is available
6. Confirm the feature does not appear in the Dashboard tab

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<!-- Add screenshot here -->
<img width="1470" height="956" alt="Screenshot 2026-03-07 at 4 40 41 PM" src="https://github.com/user-attachments/assets/5dab697d-6c79-40e2-ae41-dba7f4691038" />

