### PR TITLE
Add bar, pie, donut, and radar views to most used skills widget

### DIFF
--- a/frontend/src/renderer/skills.js
+++ b/frontend/src/renderer/skills.js
@@ -1,6 +1,16 @@
-import { isPrivateMode, authFetch, hasAuthToken, captureAuthDataEpoch, authDomWriteAllowed, getAuthToken } from "./auth.js";
+import {
+  isPrivateMode,
+  authFetch,
+  hasAuthToken,
+  captureAuthDataEpoch,
+  authDomWriteAllowed,
+  getAuthToken,
+} from "./auth.js";
 
 const SKILLS_CHART_MODE_KEY = "loom_dashboard_skills_chart_mode";
+const SKILL_CHART_MODES = ["bar", "pie", "donut", "radar"];
+const SKILL_COLORS = ["#38bdf8", "#22c55e", "#f59e0b", "#f97316", "#a78bfa"];
+
 let skillsChart = null;
 
 export async function loadMostUsedSkills() {
@@ -31,18 +41,33 @@ export async function loadMostUsedSkills() {
     return;
   }
 
+  const topSkills = result.skills.slice(0, 5);
+
   function capitalize(str) {
     if (!str) return "";
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
 
+  function getLabels() {
+    return topSkills.map((skill) => capitalize(skill.skill));
+  }
+
+  function getValues() {
+    return topSkills.map((skill) =>
+      Number((skill.confidence * 100).toFixed(1))
+    );
+  }
+
   function getChartMode() {
     const saved = localStorage.getItem(SKILLS_CHART_MODE_KEY);
-    return saved === "pie" ? "pie" : "bar";
+    return SKILL_CHART_MODES.includes(saved) ? saved : "bar";
   }
 
   function saveChartMode(mode) {
-    localStorage.setItem(SKILLS_CHART_MODE_KEY, mode === "pie" ? "pie" : "bar");
+    localStorage.setItem(
+      SKILLS_CHART_MODE_KEY,
+      SKILL_CHART_MODES.includes(mode) ? mode : "bar"
+    );
   }
 
   function destroyChart() {
@@ -52,18 +77,53 @@ export async function loadMostUsedSkills() {
     }
   }
 
+  function renderViewToggle(activeMode) {
+    return `
+      <div class="skills-view-toggle" role="tablist" aria-label="Most used skills chart type">
+        ${SKILL_CHART_MODES.map(
+          (mode) => `
+          <button
+            type="button"
+            class="skills-view-btn ${activeMode === mode ? "active" : ""}"
+            data-skills-view="${mode}"
+          >
+            ${capitalize(mode)}
+          </button>
+        `
+        ).join("")}
+      </div>
+    `;
+  }
+
+  function renderLegend() {
+    return topSkills
+      .map(
+        (skill, index) => `
+        <div class="skills-pie-legend-row">
+          <div class="skills-pie-legend-left">
+            <span
+              class="skills-pie-legend-swatch"
+              style="background: ${SKILL_COLORS[index % SKILL_COLORS.length]};"
+            ></span>
+            <span class="skills-pie-legend-name">${capitalize(skill.skill)}</span>
+          </div>
+          <span class="skills-pie-legend-meta">${(
+            skill.confidence * 100
+          ).toFixed(1)}%</span>
+        </div>
+      `
+      )
+      .join("");
+  }
+
   function renderBarView() {
     container.innerHTML = `
       <div class="skills-header-row">
         <h3 class="skills-title">Most Used Skills</h3>
-        <div class="skills-view-toggle" role="tablist" aria-label="Most used skills chart type">
-          <button type="button" class="skills-view-btn active" data-skills-view="bar">Bar</button>
-          <button type="button" class="skills-view-btn" data-skills-view="pie">Pie</button>
-        </div>
+        ${renderViewToggle("bar")}
       </div>
       <div class="skills-wrapper">
-        ${result.skills
-          .slice(0, 5)
+        ${topSkills
           .map(
             (skill) => `
             <div class="skill-row-modern">
@@ -72,7 +132,7 @@ export async function loadMostUsedSkills() {
               </div>
               <div class="skill-middle-modern">
                 <div class="skill-bar-modern">
-                  <div 
+                  <div
                     class="skill-bar-fill-modern"
                     data-width="${(skill.confidence * 100).toFixed(1)}%"
                     style="width: 0%"
@@ -82,9 +142,7 @@ export async function loadMostUsedSkills() {
                   ${(skill.confidence * 100).toFixed(1)}%
                 </span>
               </div>
-              <div class="skill-right-modern">
-                
-              </div>
+              <div class="skill-right-modern"></div>
             </div>
           `
           )
@@ -100,67 +158,150 @@ export async function loadMostUsedSkills() {
     void document.body.offsetHeight;
 
     bars.forEach((bar) => {
-      const targetWidth = bar.dataset.width;
-      bar.style.width = targetWidth;
+      bar.style.width = bar.dataset.width;
     });
   }
 
-  function renderPieView() {
+  function renderCircularView(mode = "pie") {
     container.innerHTML = `
       <div class="skills-header-row">
         <h3 class="skills-title">Most Used Skills</h3>
-        <div class="skills-view-toggle" role="tablist" aria-label="Most used skills chart type">
-          <button type="button" class="skills-view-btn" data-skills-view="bar">Bar</button>
-          <button type="button" class="skills-view-btn active" data-skills-view="pie">Pie</button>
-        </div>
+        ${renderViewToggle(mode)}
       </div>
       <div class="skills-pie-layout">
         <div class="skills-pie-canvas-wrap">
-          <canvas id="most-used-skills-pie"></canvas>
+          <canvas id="most-used-skills-chart"></canvas>
         </div>
         <div class="skills-pie-legend">
-          ${result.skills.slice(0, 5).map((skill) => `
-            <div class="skills-pie-legend-row">
-              <span class="skills-pie-legend-name">${capitalize(skill.skill)}</span>
-              <span class="skills-pie-legend-meta">${(skill.confidence * 100).toFixed(1)}%</span>
-            </div>
-          `).join("")}
+          ${renderLegend()}
         </div>
       </div>
     `;
 
-    const canvas = container.querySelector("#most-used-skills-pie");
-    if (canvas && window.Chart) {
-      skillsChart = new window.Chart(canvas, {
-        type: "pie",
-        data: {
-          labels: result.skills.slice(0, 5).map((skill) => capitalize(skill.skill)),
-          datasets: [
-            {
-              data: result.skills.slice(0, 5).map((skill) => Number((skill.confidence * 100).toFixed(1))),
-              backgroundColor: ["#38bdf8", "#22c55e", "#f59e0b", "#f97316", "#a78bfa"],
-              borderColor: "#0f172a",
-              borderWidth: 2,
-            },
-          ],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            legend: {
-              display: false,
+    const canvas = container.querySelector("#most-used-skills-chart");
+    if (!canvas || !window.Chart) return;
+
+    skillsChart = new window.Chart(canvas, {
+      type: mode === "donut" ? "doughnut" : "pie",
+      data: {
+        labels: getLabels(),
+        datasets: [
+          {
+            data: getValues(),
+            backgroundColor: SKILL_COLORS,
+            borderColor: "#0f172a",
+            borderWidth: 2,
+            hoverOffset: 8,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: mode === "donut" ? "58%" : 0,
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            callbacks: {
+              label(context) {
+                return `${context.label}: ${context.parsed.toFixed(1)}%`;
+              },
             },
           },
         },
-      });
-    }
+      },
+    });
+  }
+
+  function renderRadarView() {
+    container.innerHTML = `
+      <div class="skills-header-row">
+        <h3 class="skills-title">Most Used Skills</h3>
+        ${renderViewToggle("radar")}
+      </div>
+      <div class="skills-pie-layout">
+        <div class="skills-pie-canvas-wrap">
+          <canvas id="most-used-skills-chart"></canvas>
+        </div>
+        <div class="skills-pie-legend">
+          ${renderLegend()}
+        </div>
+      </div>
+    `;
+
+    const canvas = container.querySelector("#most-used-skills-chart");
+    if (!canvas || !window.Chart) return;
+
+    const values = getValues();
+    const maxValue = Math.max(...values, 20);
+    const suggestedMax = Math.ceil(maxValue / 5) * 5;
+
+    skillsChart = new window.Chart(canvas, {
+      type: "radar",
+      data: {
+        labels: getLabels(),
+        datasets: [
+          {
+            label: "Skill share %",
+            data: values,
+            backgroundColor: "rgba(56, 189, 248, 0.18)",
+            borderColor: "#38bdf8",
+            borderWidth: 2,
+            pointBackgroundColor: SKILL_COLORS,
+            pointBorderColor: "#0f172a",
+            pointRadius: 4,
+            pointHoverRadius: 6,
+            fill: true,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            callbacks: {
+              label(context) {
+                return `${context.label}: ${context.raw.toFixed(1)}%`;
+              },
+            },
+          },
+        },
+        scales: {
+          r: {
+            beginAtZero: true,
+            suggestedMax,
+            ticks: {
+              display: false,
+              backdropColor: "transparent",
+            },
+            angleLines: {
+              color: "rgba(255, 255, 255, 0.12)",
+            },
+            grid: {
+              color: "rgba(255, 255, 255, 0.12)",
+            },
+            pointLabels: {
+              color: "rgba(255, 255, 255, 0.9)",
+              font: {
+                size: 12,
+              },
+            },
+          },
+        },
+      },
+    });
   }
 
   function bindViewToggle() {
     container.querySelectorAll("[data-skills-view]").forEach((button) => {
       button.addEventListener("click", () => {
-        const nextMode = button.dataset.skillsView === "pie" ? "pie" : "bar";
+        const nextMode = button.dataset.skillsView || "bar";
         if (nextMode === getChartMode()) return;
         saveChartMode(nextMode);
         renderCurrentView();
@@ -170,16 +311,27 @@ export async function loadMostUsedSkills() {
 
   function renderCurrentView() {
     destroyChart();
-    if (getChartMode() === "pie") {
-      renderPieView();
-    } else {
-      renderBarView();
+
+    switch (getChartMode()) {
+      case "pie":
+        renderCircularView("pie");
+        break;
+      case "donut":
+        renderCircularView("donut");
+        break;
+      case "radar":
+        renderRadarView();
+        break;
+      case "bar":
+      default:
+        renderBarView();
+        break;
     }
+
     bindViewToggle();
   }
 
   renderCurrentView();
-
 }
 
 async function buildPrivateTimelineSkills() {
@@ -203,7 +355,9 @@ async function buildPrivateTimelineSkills() {
       const skills = Array.isArray(entry?.skills) ? entry.skills : [];
 
       skills.forEach((skill) => {
-        const name = String(skill?.skill || skill?.name || "").trim().toLowerCase();
+        const name = String(skill?.skill || skill?.name || "")
+          .trim()
+          .toLowerCase();
         if (!name) return;
 
         const weight = Number(skill?.weight ?? skill?.score ?? 1) || 1;
@@ -220,7 +374,9 @@ async function buildPrivateTimelineSkills() {
       return { empty: true };
     }
 
-    const totalWeight = [...totals.values()].reduce((sum, value) => sum + value, 0) || 1;
+    const totalWeight =
+      [...totals.values()].reduce((sum, value) => sum + value, 0) || 1;
+
     const skills = [...totals.entries()]
       .map(([skill, weight]) => ({
         skill,

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1056,7 +1056,7 @@ svg {
 .skills-title {
   font-size: 20px;
   font-weight: 600;
-  margin-bottom: 20px;
+  margin-bottom: 0;
 }
 
 #most-used-skills {
@@ -1134,6 +1134,106 @@ svg {
   border-radius: 50%;
   margin-right: 6px;
   vertical-align: middle;
+}
+
+.skills-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.skills-view-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.skills-view-btn {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.04);
+  color: #e5e7eb;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.skills-view-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.skills-view-btn.active {
+  background: rgba(77, 166, 255, 0.18);
+  border-color: rgba(77, 166, 255, 0.55);
+  box-shadow: 0 0 0 1px rgba(77, 166, 255, 0.12) inset;
+}
+
+.skills-pie-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 130px;
+  gap: 16px;
+  align-items: center;
+  min-height: 220px;
+}
+
+.skills-pie-canvas-wrap {
+  position: relative;
+  width: 100%;
+  height: 220px;
+  min-height: 220px;
+}
+
+.skills-pie-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.skills-pie-legend-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.skills-pie-legend-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.skills-pie-legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.skills-pie-legend-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.9;
+}
+
+.skills-pie-legend-meta {
+  opacity: 0.75;
+  flex-shrink: 0;
+}
+
+#most-used-skills canvas {
+  width: 100% !important;
+  height: 100% !important;
 }
 
 /* =========================================================


### PR DESCRIPTION
## 📝 Description

Adds bar, pie, donut, and radar chart views to the Most Used Skills dashboard widget and updates the widget styling to support the new chart mode controls and layout.

**Closes:** # (issue number)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] Manually tested the dashboard in the Electron app
- [x] Switched between bar, pie, donut, and radar views to confirm the widget updates correctly

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop

---

## 📸 Screenshots

<img width="1470" height="956" alt="Screenshot 2026-03-29 at 4 12 15 PM" src="https://github.com/user-attachments/assets/86eec644-df3b-434a-b8cc-feed6fb6dbf7" />
